### PR TITLE
Change lighthouse to use `@now/node@canary`

### DIFF
--- a/lighthouse/now.json
+++ b/lighthouse/now.json
@@ -13,11 +13,8 @@
   "builds": [
     {
       "src": "lighthouse/index.js",
-      "use": "@nkzawa/now-node-raw",
+      "use": "@now/node@canary",
       "config": {
-        "includeFiles": [
-          "lighthouse/node_modules/**"
-        ],
         "maxLambdaSize": "100mb"
       }
     },


### PR DESCRIPTION
We implemented a change to drop `ncc` from `@now/node`.

See https://github.com/zeit/now-builders/pull/712/files

Hopefully this will resolve the issue with the lighthouse deployment.

