### PR TITLE
feat(gcloud): use prod aliases as target urls in scheduler

### DIFF
--- a/gcloud/package.json
+++ b/gcloud/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "license": "MIT",
   "scripts": {
-    "dev": "now dev -p 5005",
+    "dev": "now dev --listen 5005",
     "lint": "eslint --fix src/**/*.ts",
     "lint-staged": "git diff --diff-filter=ACMRT --cached --name-only '*.ts' | xargs eslint --fix"
   },

--- a/gcloud/src/index.ts
+++ b/gcloud/src/index.ts
@@ -37,7 +37,7 @@ export default withUiHook(async (handlerOptions: HandlerOptions): Promise<string
 
       Object.keys(config).forEach((key: string) => {
         const project: ConfigItem = config[key]
-        
+
         if (project.googleCredentials && project.googleCredentials.private_key_id === keyId) {
           googleCredentials = project.googleCredentials
         }
@@ -297,7 +297,7 @@ export default withUiHook(async (handlerOptions: HandlerOptions): Promise<string
           </Select>
         </Box>
       </Box>
-      <$${FS.Scheduler} disabled=${!zeit.projectId} jobs=${scheduler.jobs} error=${schedulerError || scheduler.error} deployments=${scheduler.deployments} apiDisabled=${scheduler.disabled} />
+      <$${FS.Scheduler} disabled=${!zeit.projectId} jobs=${scheduler.jobs} error=${schedulerError || scheduler.error} deployments=${scheduler.deployments} productionAliases=${scheduler.productionAliases} apiDisabled=${scheduler.disabled} />
       <$${FS.Storage} disabled=${!zeit.projectId} buckets=${storage.buckets} error=${storage.error} hasCredentials=${hasCredentials} currentProject=${currentProject} />
       <$${FS.SQL} disabled=${!zeit.projectId} instances=${sql.instances} error=${sqlError || sql.error} apiDisabled=${sql.disabled} credentials=${sqlCredentials} />
       <Box>

--- a/gcloud/src/utils/ui-hook/fieldsets/scheduler.ts
+++ b/gcloud/src/utils/ui-hook/fieldsets/scheduler.ts
@@ -10,6 +10,7 @@ interface SchedulerFieldsetProps {
   error?: string | null;
   disabled?: boolean;
   deployments: any[];
+  productionAliases: string[];
   apiDisabled?: boolean;
 }
 
@@ -59,68 +60,72 @@ const Job = ({ job }: { job: cloudscheduler_v1beta1.Schema$Job }) => {
 
 const methods = ['GET', 'POST', 'DELETE', 'PUT', 'PATCH', 'HEAD', 'OPTIONS']
 
-const SchedulerFieldset = ({ jobs, error, deployments, disabled, apiDisabled }: SchedulerFieldsetProps) => html`
-  <Fieldset>
-    <FsContent>
-      <H2>Cloud Scheduler</H2>
-      <P>Run your Now deployments as cron jobs</P>
-      ${apiDisabled ? html`
-        <${Note} >
-          It appears <Link href="https://console.cloud.google.com/apis/library/cloudscheduler.googleapis.com" target="_blank">Cloud Scheduler API</Link> is disabled in your project or your service account doesn’t have access to it.
-          Enable the API in Google Cloud Console and add it to your service account to use Cloud Scheduler.
-        </${Note}>
-      ` : ''}
-      ${error && !apiDisabled ? html`
-        <${Note} type="error">
-          ${error}
-        </${Note}>
-      ` : ''}
-      ${jobs && jobs.length > 0 ? jobs.map(job => html`<${Job} job=${job} />`) : disabled ? html`<P>No project selected</P>` : html`<P>There are no Cloud Scheduler jobs in this Google Cloud project</P>`}
-      ${disabled || apiDisabled ? '' : html`
-        <Box flexDirection="column" borderTop="1px solid #eaeaea" paddingTop="10px">
-          <H2>Create Job</H2>
-          <Box display="flex" alignItems="center" marginTop="15px" marginBottom="10px">
-            <Input name="job-name" placeholder="my-job" width="160px" />
-            <Box width="10px" />
-            <Input name="job-description" placeholder="Description (Optional)" width="160px" />
-            <Box width="10px" />
-            <Select name="job-timezone" width="120px" value="Europe/Dublin">
-              ${timezones.map(tz => html`
-                <Option caption=${tz.name} value=${tz.value} />
-              `)}
-            </Select>
-            <Box width="10px" />
-            <Select name="job-method" width="80px" value="GET">
-              ${methods.map(method => html`
-                <Option caption=${method} value=${method} />
-              `)}
-            </Select>
+const SchedulerFieldset = ({ jobs, error, deployments, productionAliases, disabled, apiDisabled }: SchedulerFieldsetProps) => {
+  const targetUrls = [...productionAliases, ...(deployments || []).map(deployment => deployment.url)]
+
+  return html`
+    <Fieldset>
+      <FsContent>
+        <H2>Cloud Scheduler</H2>
+        <P>Run your Now deployments as cron jobs</P>
+        ${apiDisabled ? html`
+          <${Note} >
+            It appears <Link href="https://console.cloud.google.com/apis/library/cloudscheduler.googleapis.com" target="_blank">Cloud Scheduler API</Link> is disabled in your project or your service account doesn’t have access to it.
+            Enable the API in Google Cloud Console and add it to your service account to use Cloud Scheduler.
+          </${Note}>
+        ` : ''}
+        ${error && !apiDisabled ? html`
+          <${Note} type="error">
+            ${error}
+          </${Note}>
+        ` : ''}
+        ${jobs && jobs.length > 0 ? jobs.map(job => html`<${Job} job=${job} />`) : disabled ? html`<P>No project selected</P>` : html`<P>There are no Cloud Scheduler jobs in this Google Cloud project</P>`}
+        ${disabled || apiDisabled ? '' : html`
+          <Box flexDirection="column" borderTop="1px solid #eaeaea" paddingTop="10px">
+            <H2>Create Job</H2>
+            <Box display="flex" alignItems="center" marginTop="15px" marginBottom="10px">
+              <Input name="job-name" placeholder="my-job" width="160px" />
+              <Box width="10px" />
+              <Input name="job-description" placeholder="Description (Optional)" width="160px" />
+              <Box width="10px" />
+              <Select name="job-timezone" width="120px" value="Europe/Dublin">
+                ${timezones.map(tz => html`
+                  <Option caption=${tz.name} value=${tz.value} />
+                `)}
+              </Select>
+              <Box width="10px" />
+              <Select name="job-method" width="80px" value="GET">
+                ${methods.map(method => html`
+                  <Option caption=${method} value=${method} />
+                `)}
+              </Select>
+            </Box>
+            <Box display="flex" alignItems="center" marginTop="15px" marginBottom="10px">
+              <Select name="job-deployment" width="330px" value=${targetUrls.length > 0 ? targetUrls[0] : ''}>
+                ${targetUrls.map((targetUrl: string) => html`
+                  <Option caption=${targetUrl} value=${targetUrl} />
+                `)}
+              </Select>
+              <Box width="10px" />
+              <Input name="job-schedule" placeholder="* * * * *" width="160px" />
+              <Box width="10px" />
+              <Link href="https://crontab.guru" target="_blank">Cron syntax help</Link>
+            </Box>
+            <Textarea
+              width="500px"
+              name="job-body"
+              placeholder=${`{
+    ...
+  }`}
+            />
+            <BR />
+            <BR />
+            <Button highlight action="scheduler-create-job" small>Create New Job</Button>
           </Box>
-          <Box display="flex" alignItems="center" marginTop="15px" marginBottom="10px">
-            <Select name="job-deployment" width="330px" value=${deployments && deployments.length > 0 ? deployments[0].url : ''}>
-              ${deployments && deployments.map((deployment: any) => html`
-                <Option caption=${deployment.url} value=${deployment.url} />
-              `)}
-            </Select>
-            <Box width="10px" />
-            <Input name="job-schedule" placeholder="* * * * *" width="160px" />
-            <Box width="10px" />
-            <Link href="https://crontab.guru" target="_blank">Cron syntax help</Link>
-          </Box>
-          <Textarea
-            width="500px"
-            name="job-body"
-            placeholder=${`{
-  ...
-}`}
-          />
-          <BR />
-          <BR />
-          <Button highlight action="scheduler-create-job" small>Create New Job</Button>
-        </Box>
-      `}
-    </FsContent>
-  </Fieldset>
-`
+        `}
+      </FsContent>
+    </Fieldset>
+  `
+}
 
 export default SchedulerFieldset

--- a/gcloud/src/utils/ui-hook/scheduler-data.ts
+++ b/gcloud/src/utils/ui-hook/scheduler-data.ts
@@ -10,13 +10,16 @@ export default async function getSchedulerData(zeit: ZEIT, google: Google, curre
   }
 
   const { jobs, error, disabled } = await google.scheduler(currentProject)
-  const deployments = await zeit.deploymentsInCurrentProject()
+  const [deployments, productionAliases] = await Promise.all([
+    zeit.deploymentsInCurrentProject(),
+    zeit.productionAliasesOfCurrentProject(),
+  ])
 
   if (disabled) {
     return { disabled }
   }
 
-  return { jobs, error, deployments }
+  return { jobs, error, deployments, productionAliases }
 }
 
 export const timezones = [

--- a/gcloud/src/utils/zeit-api.ts
+++ b/gcloud/src/utils/zeit-api.ts
@@ -118,6 +118,16 @@ export default class ZEIT {
     return deployments
   }
 
+  productionAliasesOfCurrentProject = async () => {
+    console.log('Fetching production aliases of current project')
+
+    const project: any = await this.request(`/v1/projects/${this.projectId}`, {
+      teamId: this.teamId
+    } as any)
+
+    return 'production' in project.targets ? project.targets.production.alias : []
+  }
+
   listProjects = async () => {
     console.log('Fetching user projects')
 
@@ -189,7 +199,7 @@ export default class ZEIT {
       } as any)
 
       const env = await envVars.json()
-      
+
       if (!Array.isArray(env)) {
         return false
       }


### PR DESCRIPTION
Not much else to say... with this it's possible to select the aliases of the project's production deployment as target urls when creating a job in the Google Cloud Scheduler.

@coetry encouraged me to make a PR here after getting in touch with him through the support.

(I also updated the `dev` script because `-p` is deprecated in favor of `--listen`)

![image](https://user-images.githubusercontent.com/3410759/80926168-ca2fdf80-8d95-11ea-8a02-eb78b03d9f61.png)
